### PR TITLE
feat: aws-provider version bump to >= 2.46, < 4.0, terraform version bump to >= 0.12.6, < 0.14

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,19 +58,26 @@ module "key_pair" {
 * [Complete](https://github.com/terraform-aws-modules/terraform-aws-key-pair/tree/master/examples/complete) - Create EC2 key pair
 
 <!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
+## Requirements
+
+| Name | Version |
+|------|---------|
+| terraform | >= 0.12.6, < 0.14 |
+| aws | >= 2.46, < 4.0 |
+
 ## Providers
 
 | Name | Version |
 |------|---------|
-| aws | ~> 2.46 |
+| aws | >= 2.46, < 4.0 |
 
 ## Inputs
 
 | Name | Description | Type | Default | Required |
-|------|-------------|------|---------|:-----:|
+|------|-------------|------|---------|:--------:|
 | create\_key\_pair | Controls if key pair should be created | `bool` | `true` | no |
-| key\_name | The name for the key pair. | `string` | n/a | yes |
-| key\_name\_prefix | Creates a unique name beginning with the specified prefix. Conflicts with key\_name. | `string` | n/a | yes |
+| key\_name | The name for the key pair. | `string` | `null` | no |
+| key\_name\_prefix | Creates a unique name beginning with the specified prefix. Conflicts with key\_name. | `string` | `null` | no |
 | public\_key | The public key material. | `string` | `""` | no |
 | tags | A map of tags to add to key pair resource. | `map(string)` | `{}` | no |
 

--- a/examples/complete/README.md
+++ b/examples/complete/README.md
@@ -15,6 +15,10 @@ $ terraform apply
 Note that this example may create resources which cost money. Run `terraform destroy` when you don't need these resources.
 
 <!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
+## Requirements
+
+No requirements.
+
 ## Providers
 
 | Name | Version |

--- a/versions.tf
+++ b/versions.tf
@@ -1,7 +1,7 @@
 terraform {
-  required_version = "~> 0.12.6"
+  required_version = ">= 0.12.6, < 0.14"
 
   required_providers {
-    aws = "~> 2.46"
+    aws = ">= 2.46, < 4.0"
   }
 }


### PR DESCRIPTION
## Description
Bumping aws-provider requirement to ">= 2.46, < 4.0"
Bumping terraform requirement to ">= 0.12.6, < 0.14"

## Motivation and Context
There is newer terraform and provider version available.

## Breaking Changes
As stated [here](https://github.com/terraform-providers/terraform-provider-aws/releases/tag/v3.0.0)

## How Has This Been Tested?
Run example/complete locally on aws 2.46, aws 2.7, aws 3.0 and aws 3.1 