### PR TITLE
chore: update documentation and pin `terraform_docs` version to avoid future changes

### DIFF
--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -94,7 +94,7 @@ jobs:
       - name: Install pre-commit dependencies
         run: |
           pip install pre-commit
-          curl -L "$(curl -s https://api.github.com/repos/terraform-docs/terraform-docs/releases/latest | grep -o -E "https://.+?-linux-amd64" | head -n1)" > terraform-docs && chmod +x terraform-docs && sudo mv terraform-docs /usr/bin/
+          curl -L "$(curl -s https://api.github.com/repos/terraform-docs/terraform-docs/releases/latest | grep -o -E "https://.+?-v0.12.0-linux-amd64" | head -n1)" > terraform-docs && chmod +x terraform-docs && sudo mv terraform-docs /usr/bin/
           curl -L "$(curl -s https://api.github.com/repos/terraform-linters/tflint/releases/latest | grep -o -E "https://.+?_linux_amd64.zip")" > tflint.zip && unzip tflint.zip && rm tflint.zip && sudo mv tflint /usr/bin/
       - name: Execute pre-commit
         # Run all pre-commit checks on max version supported

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
   - repo: git://github.com/antonbabenko/pre-commit-terraform
-    rev: v1.47.0
+    rev: v1.48.0
     hooks:
       - id: terraform_fmt
       - id: terraform_validate

--- a/README.md
+++ b/README.md
@@ -62,42 +62,42 @@ module "key_pair" {
 
 | Name | Version |
 |------|---------|
-| terraform | >= 0.12.6 |
-| aws | >= 2.46 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.12.6 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 2.46 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| aws | >= 2.46 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 2.46 |
 
 ## Modules
 
-No Modules.
+No modules.
 
 ## Resources
 
-| Name |
-|------|
-| [aws_key_pair](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/key_pair) |
+| Name | Type |
+|------|------|
+| [aws_key_pair.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/key_pair) | resource |
 
 ## Inputs
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
-| create\_key\_pair | Controls if key pair should be created | `bool` | `true` | no |
-| key\_name | The name for the key pair. | `string` | `null` | no |
-| key\_name\_prefix | Creates a unique name beginning with the specified prefix. Conflicts with key\_name. | `string` | `null` | no |
-| public\_key | The public key material. | `string` | `""` | no |
-| tags | A map of tags to add to key pair resource. | `map(string)` | `{}` | no |
+| <a name="input_create_key_pair"></a> [create\_key\_pair](#input\_create\_key\_pair) | Controls if key pair should be created | `bool` | `true` | no |
+| <a name="input_key_name"></a> [key\_name](#input\_key\_name) | The name for the key pair. | `string` | `null` | no |
+| <a name="input_key_name_prefix"></a> [key\_name\_prefix](#input\_key\_name\_prefix) | Creates a unique name beginning with the specified prefix. Conflicts with key\_name. | `string` | `null` | no |
+| <a name="input_public_key"></a> [public\_key](#input\_public\_key) | The public key material. | `string` | `""` | no |
+| <a name="input_tags"></a> [tags](#input\_tags) | A map of tags to add to key pair resource. | `map(string)` | `{}` | no |
 
 ## Outputs
 
 | Name | Description |
 |------|-------------|
-| this\_key\_pair\_fingerprint | The MD5 public key fingerprint as specified in section 4 of RFC 4716. |
-| this\_key\_pair\_key\_name | The key pair name. |
-| this\_key\_pair\_key\_pair\_id | The key pair ID. |
+| <a name="output_this_key_pair_fingerprint"></a> [this\_key\_pair\_fingerprint](#output\_this\_key\_pair\_fingerprint) | The MD5 public key fingerprint as specified in section 4 of RFC 4716. |
+| <a name="output_this_key_pair_key_name"></a> [this\_key\_pair\_key\_name](#output\_this\_key\_pair\_key\_name) | The key pair name. |
+| <a name="output_this_key_pair_key_pair_id"></a> [this\_key\_pair\_key\_pair\_id](#output\_this\_key\_pair\_key\_pair\_id) | The key pair ID. |
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
 
 ## Authors

--- a/examples/complete/README.md
+++ b/examples/complete/README.md
@@ -19,41 +19,41 @@ Note that this example may create resources which cost money. Run `terraform des
 
 | Name | Version |
 |------|---------|
-| terraform | >= 0.12.6 |
-| aws | >= 2.46 |
-| random | >= 2.0 |
-| tls | >= 1.0 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.12.6 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 2.46 |
+| <a name="requirement_random"></a> [random](#requirement\_random) | >= 2.0 |
+| <a name="requirement_tls"></a> [tls](#requirement\_tls) | >= 1.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| random | >= 2.0 |
-| tls | >= 1.0 |
+| <a name="provider_random"></a> [random](#provider\_random) | >= 2.0 |
+| <a name="provider_tls"></a> [tls](#provider\_tls) | >= 1.0 |
 
 ## Modules
 
 | Name | Source | Version |
 |------|--------|---------|
-| key_pair | ../../ |  |
-| key_pair_external | ../../ |  |
+| <a name="module_key_pair"></a> [key\_pair](#module\_key\_pair) | ../../ |  |
+| <a name="module_key_pair_external"></a> [key\_pair\_external](#module\_key\_pair\_external) | ../../ |  |
 
 ## Resources
 
-| Name |
-|------|
-| [random_pet](https://registry.terraform.io/providers/hashicorp/random/latest/docs/resources/pet) |
-| [tls_private_key](https://registry.terraform.io/providers/hashicorp/tls/latest/docs/resources/private_key) |
+| Name | Type |
+|------|------|
+| [random_pet.this](https://registry.terraform.io/providers/hashicorp/random/latest/docs/resources/pet) | resource |
+| [tls_private_key.this](https://registry.terraform.io/providers/hashicorp/tls/latest/docs/resources/private_key) | resource |
 
 ## Inputs
 
-No input.
+No inputs.
 
 ## Outputs
 
 | Name | Description |
 |------|-------------|
-| this\_key\_pair\_fingerprint | The MD5 public key fingerprint as specified in section 4 of RFC 4716. |
-| this\_key\_pair\_key\_name | The key pair name. |
-| this\_key\_pair\_key\_pair\_id | The key pair ID. |
+| <a name="output_this_key_pair_fingerprint"></a> [this\_key\_pair\_fingerprint](#output\_this\_key\_pair\_fingerprint) | The MD5 public key fingerprint as specified in section 4 of RFC 4716. |
+| <a name="output_this_key_pair_key_name"></a> [this\_key\_pair\_key\_name](#output\_this\_key\_pair\_key\_name) | The key pair name. |
+| <a name="output_this_key_pair_key_pair_id"></a> [this\_key\_pair\_key\_pair\_id](#output\_this\_key\_pair\_key\_pair\_id) | The key pair ID. |
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->


### PR DESCRIPTION
## Description
- update documentation and pin `terraform_docs` version to avoid future changes

## Motivation and Context
- pin version to avoid unnecessary updates when a PR coincides with a version update for `terraform_docs`

## Breaking Changes
- no

## How Has This Been Tested?
- documentation change only - ci/cd should pass checks
