### PR TITLE
feat!: Update supported versions and add support for private key creation

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
   - repo: https://github.com/antonbabenko/pre-commit-terraform
-    rev: v1.62.3
+    rev: v1.74.1
     hooks:
       - id: terraform_fmt
       - id: terraform_validate
@@ -23,7 +23,7 @@ repos:
           - '--args=--only=terraform_standard_module_structure'
           - '--args=--only=terraform_workspace_remote'
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.1.0
+    rev: v4.3.0
     hooks:
       - id: check-merge-conflict
       - id: end-of-file-fixer

--- a/README.md
+++ b/README.md
@@ -1,10 +1,23 @@
 # AWS Key Pair Terraform module
 
-Terraform module which creates EC2 key pair resource by Terraform AWS provider.
+Terraform module which creates EC2 key pair on AWS.
+
+[![SWUbanner](https://raw.githubusercontent.com/vshymanskyy/StandWithUkraine/main/banner2-direct.svg)](https://github.com/vshymanskyy/StandWithUkraine/blob/main/docs/README.md)
 
 ## Usage
 
-### Create new EC2 key pair
+### EC2 Key pair w/ module created key material
+
+```hcl
+module "key_pair" {
+  source = "terraform-aws-modules/key-pair/aws"
+
+  key_name           = "deployer-one"
+  create_private_key = true
+}
+```
+
+### EC2 Key pair w/ externally created public key material
 
 ```hcl
 resource "tls_private_key" "this" {
@@ -14,20 +27,19 @@ resource "tls_private_key" "this" {
 module "key_pair" {
   source = "terraform-aws-modules/key-pair/aws"
 
-  key_name   = "deployer-one"
-  public_key = tls_private_key.this.public_key_openssh
+  key_name   = "deployer-two"
+  public_key = trimspace(tls_private_key.this.public_key_openssh)
 }
 ```
 
-### Import existing public key as EC2 key pair
+### EC2 Key pair w/ existing public key material
 
 ```hcl
 module "key_pair" {
   source = "terraform-aws-modules/key-pair/aws"
 
-  key_name   = "deployer-two"
+  key_name   = "deployer-three"
   public_key = "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQD3F6tyPEFEzV0LX3X8BsXdMsQz1x2cEikKDEY0aIj41qgxMCP/iteneqXSIFZBp5vizPvaoIR3Um9xK7PGoW8giupGn+EPuxIA4cDM4vzOqOkiMPhz5XK0whEjkVzTo4+S0puvDZuwIsdiW9mxhJc7tgBNL0cYlWSYVkz4G/fslNfRPW5mYAM49f4fhtxPb5ok4Q2Lg9dPKVHO/Bgeu5woMc7RY0p1ej6D4CKFE6lymSDJpW0YHX/wqE9+cfEauh7xZcG0q9t2ta6F6fmX0agvpFyZo8aFbXeUBr7osSCJNgvavWbM/06niWrOvYX2xwWdhXmXSrbX8ZbabVohBK41 email@example.com"
-
 }
 ```
 
@@ -40,7 +52,7 @@ Sometimes you need to have a way to create key pair conditionally but Terraform 
 module "key_pair" {
   source = "terraform-aws-modules/key-pair/aws"
 
-  create_key_pair = false
+  create = false
   # ... omitted
 }
 ```
@@ -54,14 +66,16 @@ module "key_pair" {
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.12.6 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 2.46 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.0 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 4.21 |
+| <a name="requirement_tls"></a> [tls](#requirement\_tls) | >= 3.4 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 2.46 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 4.21 |
+| <a name="provider_tls"></a> [tls](#provider\_tls) | >= 3.4 |
 
 ## Modules
 
@@ -72,24 +86,36 @@ No modules.
 | Name | Type |
 |------|------|
 | [aws_key_pair.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/key_pair) | resource |
+| [tls_private_key.this](https://registry.terraform.io/providers/hashicorp/tls/latest/docs/resources/private_key) | resource |
 
 ## Inputs
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
-| <a name="input_create_key_pair"></a> [create\_key\_pair](#input\_create\_key\_pair) | Controls if key pair should be created | `bool` | `true` | no |
-| <a name="input_key_name"></a> [key\_name](#input\_key\_name) | The name for the key pair. | `string` | `null` | no |
-| <a name="input_key_name_prefix"></a> [key\_name\_prefix](#input\_key\_name\_prefix) | Creates a unique name beginning with the specified prefix. Conflicts with key\_name. | `string` | `null` | no |
-| <a name="input_public_key"></a> [public\_key](#input\_public\_key) | The public key material. | `string` | `""` | no |
-| <a name="input_tags"></a> [tags](#input\_tags) | A map of tags to add to key pair resource. | `map(string)` | `{}` | no |
+| <a name="input_create"></a> [create](#input\_create) | Determines whether resources will be created (affects all resources) | `bool` | `true` | no |
+| <a name="input_create_private_key"></a> [create\_private\_key](#input\_create\_private\_key) | Determines whether a private key will be created | `bool` | `false` | no |
+| <a name="input_key_name"></a> [key\_name](#input\_key\_name) | The name for the key pair. Conflicts with `key_name_prefix` | `string` | `null` | no |
+| <a name="input_key_name_prefix"></a> [key\_name\_prefix](#input\_key\_name\_prefix) | Creates a unique name beginning with the specified prefix. Conflicts with `key_name` | `string` | `null` | no |
+| <a name="input_private_key_algorithm"></a> [private\_key\_algorithm](#input\_private\_key\_algorithm) | Name of the algorithm to use when generating the private key. Currently-supported values are `RSA` and `ED25519` | `string` | `"RSA"` | no |
+| <a name="input_private_key_rsa_bits"></a> [private\_key\_rsa\_bits](#input\_private\_key\_rsa\_bits) | When algorithm is `RSA`, the size of the generated RSA key, in bits (default: `4096`) | `number` | `4096` | no |
+| <a name="input_public_key"></a> [public\_key](#input\_public\_key) | The public key material | `string` | `""` | no |
+| <a name="input_tags"></a> [tags](#input\_tags) | A map of tags to add to all resources | `map(string)` | `{}` | no |
 
 ## Outputs
 
 | Name | Description |
 |------|-------------|
-| <a name="output_key_pair_fingerprint"></a> [key\_pair\_fingerprint](#output\_key\_pair\_fingerprint) | The MD5 public key fingerprint as specified in section 4 of RFC 4716. |
-| <a name="output_key_pair_key_name"></a> [key\_pair\_key\_name](#output\_key\_pair\_key\_name) | The key pair name. |
-| <a name="output_key_pair_key_pair_id"></a> [key\_pair\_key\_pair\_id](#output\_key\_pair\_key\_pair\_id) | The key pair ID. |
+| <a name="output_key_pair_arn"></a> [key\_pair\_arn](#output\_key\_pair\_arn) | The key pair ARN |
+| <a name="output_key_pair_fingerprint"></a> [key\_pair\_fingerprint](#output\_key\_pair\_fingerprint) | The MD5 public key fingerprint as specified in section 4 of RFC 4716 |
+| <a name="output_key_pair_id"></a> [key\_pair\_id](#output\_key\_pair\_id) | The key pair ID |
+| <a name="output_key_pair_name"></a> [key\_pair\_name](#output\_key\_pair\_name) | The key pair name |
+| <a name="output_private_key_id"></a> [private\_key\_id](#output\_private\_key\_id) | Unique identifier for this resource: hexadecimal representation of the SHA1 checksum of the resource |
+| <a name="output_private_key_openssh"></a> [private\_key\_openssh](#output\_private\_key\_openssh) | Private key data in OpenSSH PEM (RFC 4716) format |
+| <a name="output_private_key_pem"></a> [private\_key\_pem](#output\_private\_key\_pem) | Private key data in PEM (RFC 1421) format |
+| <a name="output_public_key_fingerprint_md5"></a> [public\_key\_fingerprint\_md5](#output\_public\_key\_fingerprint\_md5) | The fingerprint of the public key data in OpenSSH MD5 hash format, e.g. `aa:bb:cc:....` Only available if the selected private key format is compatible, similarly to `public_key_openssh` and the ECDSA P224 limitations |
+| <a name="output_public_key_fingerprint_sha256"></a> [public\_key\_fingerprint\_sha256](#output\_public\_key\_fingerprint\_sha256) | The fingerprint of the public key data in OpenSSH SHA256 hash format, e.g. `SHA256:....` Only available if the selected private key format is compatible, similarly to `public_key_openssh` and the ECDSA P224 limitations |
+| <a name="output_public_key_openssh"></a> [public\_key\_openssh](#output\_public\_key\_openssh) | The public key data in "Authorized Keys" format. This is populated only if the configured private key is supported: this includes all `RSA` and `ED25519` keys |
+| <a name="output_public_key_pem"></a> [public\_key\_pem](#output\_public\_key\_pem) | Public key data in PEM (RFC 1421) format |
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
 
 ## Authors

--- a/UPGRADE-2.0.md
+++ b/UPGRADE-2.0.md
@@ -1,0 +1,66 @@
+# Upgrade from v1.x to v2.x
+
+Please consult the `examples` directory for reference example configurations. If you find a bug, please open an issue with supporting configuration to reproduce.
+
+## List of backwards incompatible changes
+
+- Minimum supported version of Terraform AWS provider updated to v4.21 to support latest resources
+- Minimum supported version of Terraform updated to v1.0
+- The variable `create_key_pair` is now simply `create`
+
+## Additional changes
+
+### Added
+
+- Support for creating private key within the module using the commonly used `tls_private_key` resource
+
+### Modified
+
+  - None
+
+### Removed
+
+  - None
+
+### Variable and output changes
+
+1. Removed variables:
+
+  - None
+
+2. Renamed variables:
+
+  - `create_key_pair` -> `create`
+
+3. Added variables:
+
+  - `create_private_key`
+  - `private_key_algorithm`
+  - `private_key_rsa_bits`
+
+4. Removed outputs:
+
+    - None
+
+5. Renamed outputs:
+
+    - `key_pair_key_pair_id` -> `key_pair_id`
+    - `key_pair_key_name` -> `key_pair_name`
+
+
+6. Added outputs:
+
+    - `key_pair_arn`
+    - `private_key_id`
+    - `private_key_openssh`
+    - `private_key_pem`
+    - `public_key_fingerprint_md5`
+    - `public_key_fingerprint_sha256`
+    - `public_key_openssh`
+    - `public_key_pem`
+
+## Upgrade Migrations
+
+### State Move Commands
+
+None required

--- a/examples/README.md
+++ b/examples/README.md
@@ -1,0 +1,8 @@
+# Examples
+
+Please note - the examples provided serve two primary means:
+
+1. Show users working examples of the various ways in which the module can be configured and features supported
+2. A means of testing/validating module changes
+
+Please do not mistake the examples provided as "best practices". It is up to users to consult the AWS service documentation for best practices, usage recommendations, etc.

--- a/examples/complete/README.md
+++ b/examples/complete/README.md
@@ -2,6 +2,9 @@
 
 Configuration in this directory creates EC2 key pair
 
+- One key pair with a module created private key (private/public key pair)
+- One key pair with external provided public key material
+
 ## Usage
 
 To run this example you need to execute:
@@ -19,30 +22,28 @@ Note that this example may create resources which cost money. Run `terraform des
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.12.6 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 2.46 |
-| <a name="requirement_random"></a> [random](#requirement\_random) | >= 2.0 |
-| <a name="requirement_tls"></a> [tls](#requirement\_tls) | >= 1.0 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.0 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 4.21 |
+| <a name="requirement_tls"></a> [tls](#requirement\_tls) | >= 3.4 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_random"></a> [random](#provider\_random) | >= 2.0 |
-| <a name="provider_tls"></a> [tls](#provider\_tls) | >= 1.0 |
+| <a name="provider_tls"></a> [tls](#provider\_tls) | >= 3.4 |
 
 ## Modules
 
 | Name | Source | Version |
 |------|--------|---------|
 | <a name="module_key_pair"></a> [key\_pair](#module\_key\_pair) | ../../ | n/a |
+| <a name="module_key_pair_disabled"></a> [key\_pair\_disabled](#module\_key\_pair\_disabled) | ../../ | n/a |
 | <a name="module_key_pair_external"></a> [key\_pair\_external](#module\_key\_pair\_external) | ../../ | n/a |
 
 ## Resources
 
 | Name | Type |
 |------|------|
-| [random_pet.this](https://registry.terraform.io/providers/hashicorp/random/latest/docs/resources/pet) | resource |
 | [tls_private_key.this](https://registry.terraform.io/providers/hashicorp/tls/latest/docs/resources/private_key) | resource |
 
 ## Inputs
@@ -53,7 +54,26 @@ No inputs.
 
 | Name | Description |
 |------|-------------|
-| <a name="output_key_pair_fingerprint"></a> [key\_pair\_fingerprint](#output\_key\_pair\_fingerprint) | The MD5 public key fingerprint as specified in section 4 of RFC 4716. |
-| <a name="output_key_pair_key_name"></a> [key\_pair\_key\_name](#output\_key\_pair\_key\_name) | The key pair name. |
-| <a name="output_key_pair_key_pair_id"></a> [key\_pair\_key\_pair\_id](#output\_key\_pair\_key\_pair\_id) | The key pair ID. |
+| <a name="output_external_key_pair_arn"></a> [external\_key\_pair\_arn](#output\_external\_key\_pair\_arn) | The key pair ARN |
+| <a name="output_external_key_pair_fingerprint"></a> [external\_key\_pair\_fingerprint](#output\_external\_key\_pair\_fingerprint) | The MD5 public key fingerprint as specified in section 4 of RFC 4716 |
+| <a name="output_external_key_pair_id"></a> [external\_key\_pair\_id](#output\_external\_key\_pair\_id) | The key pair ID |
+| <a name="output_external_key_pair_name"></a> [external\_key\_pair\_name](#output\_external\_key\_pair\_name) | The key pair name |
+| <a name="output_external_private_key_id"></a> [external\_private\_key\_id](#output\_external\_private\_key\_id) | Unique identifier for this resource: hexadecimal representation of the SHA1 checksum of the resource |
+| <a name="output_external_private_key_openssh"></a> [external\_private\_key\_openssh](#output\_external\_private\_key\_openssh) | Private key data in OpenSSH PEM (RFC 4716) format |
+| <a name="output_external_private_key_pem"></a> [external\_private\_key\_pem](#output\_external\_private\_key\_pem) | Private key data in PEM (RFC 1421) format |
+| <a name="output_external_public_key_fingerprint_md5"></a> [external\_public\_key\_fingerprint\_md5](#output\_external\_public\_key\_fingerprint\_md5) | The fingerprint of the public key data in OpenSSH MD5 hash format, e.g. `aa:bb:cc:....` Only available if the selected private key format is compatible, similarly to `public_key_openssh` and the ECDSA P224 limitations |
+| <a name="output_external_public_key_fingerprint_sha256"></a> [external\_public\_key\_fingerprint\_sha256](#output\_external\_public\_key\_fingerprint\_sha256) | The fingerprint of the public key data in OpenSSH SHA256 hash format, e.g. `SHA256:....` Only available if the selected private key format is compatible, similarly to `public_key_openssh` and the ECDSA P224 limitations |
+| <a name="output_external_public_key_openssh"></a> [external\_public\_key\_openssh](#output\_external\_public\_key\_openssh) | The public key data in "Authorized Keys" format. This is populated only if the configured private key is supported: this includes all `RSA` and `ED25519` keys |
+| <a name="output_external_public_key_pem"></a> [external\_public\_key\_pem](#output\_external\_public\_key\_pem) | Public key data in PEM (RFC 1421) format |
+| <a name="output_key_pair_arn"></a> [key\_pair\_arn](#output\_key\_pair\_arn) | The key pair ARN |
+| <a name="output_key_pair_fingerprint"></a> [key\_pair\_fingerprint](#output\_key\_pair\_fingerprint) | The MD5 public key fingerprint as specified in section 4 of RFC 4716 |
+| <a name="output_key_pair_id"></a> [key\_pair\_id](#output\_key\_pair\_id) | The key pair ID |
+| <a name="output_key_pair_name"></a> [key\_pair\_name](#output\_key\_pair\_name) | The key pair name |
+| <a name="output_private_key_id"></a> [private\_key\_id](#output\_private\_key\_id) | Unique identifier for this resource: hexadecimal representation of the SHA1 checksum of the resource |
+| <a name="output_private_key_openssh"></a> [private\_key\_openssh](#output\_private\_key\_openssh) | Private key data in OpenSSH PEM (RFC 4716) format |
+| <a name="output_private_key_pem"></a> [private\_key\_pem](#output\_private\_key\_pem) | Private key data in PEM (RFC 1421) format |
+| <a name="output_public_key_fingerprint_md5"></a> [public\_key\_fingerprint\_md5](#output\_public\_key\_fingerprint\_md5) | The fingerprint of the public key data in OpenSSH MD5 hash format, e.g. `aa:bb:cc:....` Only available if the selected private key format is compatible, similarly to `public_key_openssh` and the ECDSA P224 limitations |
+| <a name="output_public_key_fingerprint_sha256"></a> [public\_key\_fingerprint\_sha256](#output\_public\_key\_fingerprint\_sha256) | The fingerprint of the public key data in OpenSSH SHA256 hash format, e.g. `SHA256:....` Only available if the selected private key format is compatible, similarly to `public_key_openssh` and the ECDSA P224 limitations |
+| <a name="output_public_key_openssh"></a> [public\_key\_openssh](#output\_public\_key\_openssh) | The public key data in "Authorized Keys" format. This is populated only if the configured private key is supported: this includes all `RSA` and `ED25519` keys |
+| <a name="output_public_key_pem"></a> [public\_key\_pem](#output\_public\_key\_pem) | Public key data in PEM (RFC 1421) format |
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/examples/complete/outputs.tf
+++ b/examples/complete/outputs.tf
@@ -1,14 +1,121 @@
-output "key_pair_key_name" {
-  description = "The key pair name."
-  value       = module.key_pair.key_pair_key_name
+################################################################################
+# Key Pair
+################################################################################
+
+output "key_pair_id" {
+  description = "The key pair ID"
+  value       = module.key_pair.key_pair_id
 }
 
-output "key_pair_key_pair_id" {
-  description = "The key pair ID."
-  value       = module.key_pair.key_pair_key_pair_id
+output "key_pair_arn" {
+  description = "The key pair ARN"
+  value       = module.key_pair.key_pair_arn
+}
+
+output "key_pair_name" {
+  description = "The key pair name"
+  value       = module.key_pair.key_pair_name
 }
 
 output "key_pair_fingerprint" {
-  description = "The MD5 public key fingerprint as specified in section 4 of RFC 4716."
+  description = "The MD5 public key fingerprint as specified in section 4 of RFC 4716"
   value       = module.key_pair.key_pair_fingerprint
+}
+
+output "private_key_id" {
+  description = "Unique identifier for this resource: hexadecimal representation of the SHA1 checksum of the resource"
+  value       = module.key_pair.private_key_id
+}
+
+output "private_key_openssh" {
+  description = "Private key data in OpenSSH PEM (RFC 4716) format"
+  value       = module.key_pair.private_key_openssh
+  sensitive   = true
+}
+
+output "private_key_pem" {
+  description = "Private key data in PEM (RFC 1421) format"
+  value       = module.key_pair.private_key_pem
+  sensitive   = true
+}
+
+output "public_key_fingerprint_md5" {
+  description = "The fingerprint of the public key data in OpenSSH MD5 hash format, e.g. `aa:bb:cc:....` Only available if the selected private key format is compatible, similarly to `public_key_openssh` and the ECDSA P224 limitations"
+  value       = module.key_pair.public_key_fingerprint_md5
+}
+
+output "public_key_fingerprint_sha256" {
+  description = "The fingerprint of the public key data in OpenSSH SHA256 hash format, e.g. `SHA256:....` Only available if the selected private key format is compatible, similarly to `public_key_openssh` and the ECDSA P224 limitations"
+  value       = module.key_pair.public_key_fingerprint_sha256
+}
+
+output "public_key_openssh" {
+  description = "The public key data in \"Authorized Keys\" format. This is populated only if the configured private key is supported: this includes all `RSA` and `ED25519` keys"
+  value       = module.key_pair.public_key_openssh
+}
+
+output "public_key_pem" {
+  description = "Public key data in PEM (RFC 1421) format"
+  value       = module.key_pair.public_key_pem
+}
+
+################################################################################
+# Key Pair - External
+################################################################################
+
+output "external_key_pair_id" {
+  description = "The key pair ID"
+  value       = module.key_pair_external.key_pair_id
+}
+
+output "external_key_pair_arn" {
+  description = "The key pair ARN"
+  value       = module.key_pair_external.key_pair_arn
+}
+
+output "external_key_pair_name" {
+  description = "The key pair name"
+  value       = module.key_pair_external.key_pair_name
+}
+
+output "external_key_pair_fingerprint" {
+  description = "The MD5 public key fingerprint as specified in section 4 of RFC 4716"
+  value       = module.key_pair_external.key_pair_fingerprint
+}
+
+output "external_private_key_id" {
+  description = "Unique identifier for this resource: hexadecimal representation of the SHA1 checksum of the resource"
+  value       = module.key_pair_external.private_key_id
+}
+
+output "external_private_key_openssh" {
+  description = "Private key data in OpenSSH PEM (RFC 4716) format"
+  value       = module.key_pair_external.private_key_openssh
+  sensitive   = true
+}
+
+output "external_private_key_pem" {
+  description = "Private key data in PEM (RFC 1421) format"
+  value       = module.key_pair_external.private_key_pem
+  sensitive   = true
+}
+
+output "external_public_key_fingerprint_md5" {
+  description = "The fingerprint of the public key data in OpenSSH MD5 hash format, e.g. `aa:bb:cc:....` Only available if the selected private key format is compatible, similarly to `public_key_openssh` and the ECDSA P224 limitations"
+  value       = module.key_pair_external.public_key_fingerprint_md5
+}
+
+output "external_public_key_fingerprint_sha256" {
+  description = "The fingerprint of the public key data in OpenSSH SHA256 hash format, e.g. `SHA256:....` Only available if the selected private key format is compatible, similarly to `public_key_openssh` and the ECDSA P224 limitations"
+  value       = module.key_pair_external.public_key_fingerprint_sha256
+}
+
+output "external_public_key_openssh" {
+  description = "The public key data in \"Authorized Keys\" format. This is populated only if the configured private key is supported: this includes all `RSA` and `ED25519` keys"
+  value       = module.key_pair_external.public_key_openssh
+}
+
+output "external_public_key_pem" {
+  description = "Public key data in PEM (RFC 1421) format"
+  value       = module.key_pair_external.public_key_pem
 }

--- a/examples/complete/versions.tf
+++ b/examples/complete/versions.tf
@@ -1,9 +1,14 @@
 terraform {
-  required_version = ">= 0.12.6"
+  required_version = ">= 1.0"
 
   required_providers {
-    aws    = ">= 2.46"
-    random = ">= 2.0"
-    tls    = ">= 1.0"
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">= 4.21"
+    }
+    tls = {
+      source  = "hashicorp/tls"
+      version = ">= 3.4"
+    }
   }
 }

--- a/main.tf
+++ b/main.tf
@@ -1,9 +1,24 @@
+################################################################################
+# Key Pair
+################################################################################
+
 resource "aws_key_pair" "this" {
-  count = var.create_key_pair ? 1 : 0
+  count = var.create ? 1 : 0
 
   key_name        = var.key_name
   key_name_prefix = var.key_name_prefix
-  public_key      = var.public_key
+  public_key      = var.create_private_key ? trimspace(tls_private_key.this[0].public_key_openssh) : var.public_key
 
   tags = var.tags
+}
+
+################################################################################
+# Private Key
+################################################################################
+
+resource "tls_private_key" "this" {
+  count = var.create && var.create_private_key ? 1 : 0
+
+  algorithm = var.private_key_algorithm
+  rsa_bits  = var.private_key_rsa_bits
 }

--- a/outputs.tf
+++ b/outputs.tf
@@ -1,14 +1,64 @@
-output "key_pair_key_name" {
-  description = "The key pair name."
-  value       = concat(aws_key_pair.this.*.key_name, [""])[0]
+################################################################################
+# Key Pair
+################################################################################
+
+output "key_pair_id" {
+  description = "The key pair ID"
+  value       = try(aws_key_pair.this[0].key_pair_id, "")
 }
 
-output "key_pair_key_pair_id" {
-  description = "The key pair ID."
-  value       = concat(aws_key_pair.this.*.key_pair_id, [""])[0]
+output "key_pair_arn" {
+  description = "The key pair ARN"
+  value       = try(aws_key_pair.this[0].arn, "")
+}
+
+output "key_pair_name" {
+  description = "The key pair name"
+  value       = try(aws_key_pair.this[0].key_name, "")
 }
 
 output "key_pair_fingerprint" {
-  description = "The MD5 public key fingerprint as specified in section 4 of RFC 4716."
-  value       = concat(aws_key_pair.this.*.fingerprint, [""])[0]
+  description = "The MD5 public key fingerprint as specified in section 4 of RFC 4716"
+  value       = try(aws_key_pair.this[0].fingerprint, "")
+}
+
+################################################################################
+# Private Key
+################################################################################
+
+output "private_key_id" {
+  description = "Unique identifier for this resource: hexadecimal representation of the SHA1 checksum of the resource"
+  value       = try(tls_private_key.this[0].id, "")
+}
+
+output "private_key_openssh" {
+  description = "Private key data in OpenSSH PEM (RFC 4716) format"
+  value       = try(trimspace(tls_private_key.this[0].private_key_openssh), "")
+  sensitive   = true
+}
+
+output "private_key_pem" {
+  description = "Private key data in PEM (RFC 1421) format"
+  value       = try(trimspace(tls_private_key.this[0].private_key_pem), "")
+  sensitive   = true
+}
+
+output "public_key_fingerprint_md5" {
+  description = "The fingerprint of the public key data in OpenSSH MD5 hash format, e.g. `aa:bb:cc:....` Only available if the selected private key format is compatible, similarly to `public_key_openssh` and the ECDSA P224 limitations"
+  value       = try(tls_private_key.this[0].public_key_fingerprint_md5, "")
+}
+
+output "public_key_fingerprint_sha256" {
+  description = "The fingerprint of the public key data in OpenSSH SHA256 hash format, e.g. `SHA256:....` Only available if the selected private key format is compatible, similarly to `public_key_openssh` and the ECDSA P224 limitations"
+  value       = try(tls_private_key.this[0].public_key_fingerprint_sha256, "")
+}
+
+output "public_key_openssh" {
+  description = "The public key data in \"Authorized Keys\" format. This is populated only if the configured private key is supported: this includes all `RSA` and `ED25519` keys"
+  value       = try(trimspace(tls_private_key.this[0].public_key_openssh), "")
+}
+
+output "public_key_pem" {
+  description = "Public key data in PEM (RFC 1421) format"
+  value       = try(trimspace(tls_private_key.this[0].public_key_pem), "")
 }

--- a/variables.tf
+++ b/variables.tf
@@ -1,29 +1,55 @@
-variable "create_key_pair" {
-  description = "Controls if key pair should be created"
+variable "create" {
+  description = "Determines whether resources will be created (affects all resources)"
   type        = bool
   default     = true
 }
 
+variable "tags" {
+  description = "A map of tags to add to all resources"
+  type        = map(string)
+  default     = {}
+}
+
+################################################################################
+# Key Pair
+################################################################################
+
 variable "key_name" {
-  description = "The name for the key pair."
+  description = "The name for the key pair. Conflicts with `key_name_prefix`"
   type        = string
   default     = null
 }
 
 variable "key_name_prefix" {
-  description = "Creates a unique name beginning with the specified prefix. Conflicts with key_name."
+  description = "Creates a unique name beginning with the specified prefix. Conflicts with `key_name`"
   type        = string
   default     = null
 }
 
 variable "public_key" {
-  description = "The public key material."
+  description = "The public key material"
   type        = string
   default     = ""
 }
 
-variable "tags" {
-  description = "A map of tags to add to key pair resource."
-  type        = map(string)
-  default     = {}
+################################################################################
+# Private Key
+################################################################################
+
+variable "create_private_key" {
+  description = "Determines whether a private key will be created"
+  type        = bool
+  default     = false
+}
+
+variable "private_key_algorithm" {
+  description = "Name of the algorithm to use when generating the private key. Currently-supported values are `RSA` and `ED25519`"
+  type        = string
+  default     = "RSA"
+}
+
+variable "private_key_rsa_bits" {
+  description = "When algorithm is `RSA`, the size of the generated RSA key, in bits (default: `4096`)"
+  type        = number
+  default     = 4096
 }

--- a/versions.tf
+++ b/versions.tf
@@ -1,7 +1,14 @@
 terraform {
-  required_version = ">= 0.12.6"
+  required_version = ">= 1.0"
 
   required_providers {
-    aws = ">= 2.46"
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">= 4.21"
+    }
+    tls = {
+      source  = "hashicorp/tls"
+      version = ">= 3.4"
+    }
   }
 }


### PR DESCRIPTION
## Description
- Minimum supported version of Terraform AWS provider updated to v4.21 to support latest resources
- Minimum supported version of Terraform updated to v1.0
- The variable `create_key_pair` is now simply `create`

See [`UPGRADE-2.0.md`](https://github.com/bryantbiggs/terraform-aws-key-pair/blob/refactor/upgrade/UPGRADE-2.0.md) for full list of chagnes

## Motivation and Context
- Update versions used to latest GA versions
- Add support for creating private/public keys used in key pair resource

## Breaking Changes
- Yes

## How Has This Been Tested?
- [x] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [x] I have tested and validated these changes using one or more of the provided `examples/*` projects
<!--- Users should start with an existing example as its written, deploy it, then check their changes against it -->
<!--- This will highlight breaking/disruptive changes. Once you have checked, deploy your changes to verify -->
<!--- Please describe how you tested your changes -->
- [x] I have executed `pre-commit run -a` on my pull request
<!--- Please see https://github.com/antonbabenko/pre-commit-terraform#how-to-install for how to install -->
